### PR TITLE
Fix handler resource leak in progress_custom.go

### DIFF
--- a/examples/progress_custom.go
+++ b/examples/progress_custom.go
@@ -49,6 +49,7 @@ func doSomeLongTaskCustom(cancelCtx, ctx context.Context, b *bot.Bot, p *progres
 		time.Sleep(time.Second)
 		if v == 100 {
 			p.Delete(ctx, b)
+			p.Done(ctx, b)
 			b.SendMessage(ctx, &bot.SendMessageParams{
 				ChatID: chatID,
 				Text:   "Completed",

--- a/progress/readme.md
+++ b/progress/readme.md
@@ -63,6 +63,7 @@ func doSomeLongTaskSimple(ctx context.Context, b *bot.Bot, p *progress.Progress,
 		time.Sleep(time.Second)
 		if v == 100 {
 			p.Delete(ctx, b)
+			p.Done(ctx, b)
 			b.SendMessage(ctx, &bot.SendMessageParams{
 				ChatID: chatID,
 				Text:   "Completed",


### PR DESCRIPTION
It seems that registering an optional Cancel handler is causing a resource leak in `progress_custom.go`. I added a new `onCancelHandlerId` field to store the handler ID and then unregister it on cancel or using then new `Done` method.