### PR TITLE
Optional callback handler for the reply keyboard

### DIFF
--- a/keyboard/reply/add.go
+++ b/keyboard/reply/add.go
@@ -17,7 +17,9 @@ func (kb *ReplyKeyboard) Button(text string, b *bot.Bot, matchType bot.MatchType
 		Text: text,
 	})
 
-	b.RegisterHandler(bot.HandlerTypeMessageText, text, matchType, handler)
+	if handler != nil {
+		b.RegisterHandler(bot.HandlerTypeMessageText, text, matchType, handler)
+	}
 
 	return kb
 }


### PR DESCRIPTION
I’m adding an option to create a callback handler for the reply keyboard because, theoretically, the keyboard text might match regular messages in the future. Since there’s no way to use a generated prefix to handle text specifically from the keyboard, we risk processing all user messages in the chat that match the button handler. This solution will prevent that by consolidating all reply button handling into a single unified handler, without registering individual handlers during button creation.