### PR TITLE
v0.4.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.0 (2024-10-08)
+
+- update bot lib version to v1.8.3
+- add option `paginator.WithoutEmptyButtons`
+- BREAKING: change signature of `dialog.New()`, `paginator.New()`, `progress.New()`, `slider.New()` method. Add `bot.Bot` as first argument
+
 ## v0.3.2 (2024-05-20)
 
 - added 'NoDeleteAfterSelect' and 'NoDeleteAfterCancel' datepicker & slider options methods (#8) 

--- a/dialog/dialog.go
+++ b/dialog/dialog.go
@@ -22,7 +22,7 @@ type Dialog struct {
 	callbackHandlerID string
 }
 
-func New(nodes []Node, opts ...Option) *Dialog {
+func New(b *bot.Bot, nodes []Node, opts ...Option) *Dialog {
 	p := &Dialog{
 		prefix:  bot.RandomString(16),
 		onError: defaultOnError,
@@ -32,6 +32,8 @@ func New(nodes []Node, opts ...Option) *Dialog {
 	for _, opt := range opts {
 		opt(p)
 	}
+
+	p.callbackHandlerID = b.RegisterHandler(bot.HandlerTypeCallbackQueryData, p.prefix, bot.MatchTypePrefix, p.callback)
 
 	return p
 }
@@ -57,8 +59,6 @@ func (d *Dialog) showNode(ctx context.Context, b *bot.Bot, chatID any, node Node
 }
 
 func (d *Dialog) Show(ctx context.Context, b *bot.Bot, chatID any, nodeID string) (*models.Message, error) {
-	d.callbackHandlerID = b.RegisterHandler(bot.HandlerTypeCallbackQueryData, d.prefix, bot.MatchTypePrefix, d.callback)
-
 	node, ok := d.findNode(nodeID)
 	if !ok {
 		return nil, fmt.Errorf("failed to find node with id %s", nodeID)

--- a/examples/dialog.go
+++ b/examples/dialog.go
@@ -18,13 +18,13 @@ var (
 )
 
 func handlerDialog(ctx context.Context, b *bot.Bot, update *models.Update) {
-	p := dialog.New(dialogNodes, dialog.WithPrefix("dialog"))
+	p := dialog.New(b, dialogNodes, dialog.WithPrefix("dialog"))
 
 	p.Show(ctx, b, update.Message.Chat.ID, "start")
 }
 
 func handlerDialogInline(ctx context.Context, b *bot.Bot, update *models.Update) {
-	p := dialog.New(dialogNodes, dialog.Inline())
+	p := dialog.New(b, dialogNodes, dialog.Inline())
 
 	p.Show(ctx, b, update.Message.Chat.ID, "start")
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -43,8 +43,8 @@ func main() {
 	initDatePickerCustom(b)
 	initInlineKeyboard(b)
 	initReplyKeyboard(b)
-	initPaginator()
-	initProgressSimple()
+	initPaginator(b)
+	initProgressSimple(b)
 
 	b.Start(ctx)
 }

--- a/examples/paginator.go
+++ b/examples/paginator.go
@@ -55,13 +55,13 @@ var (
 
 var demoPaginator *paginator.Paginator
 
-func initPaginator() {
+func initPaginator(b *bot.Bot) {
 	opts := []paginator.Option{
 		paginator.PerPage(3),
 		paginator.WithCloseButton("Close"),
 		paginator.WithPrefix("paginator"),
 	}
-	demoPaginator = paginator.New(data, opts...)
+	demoPaginator = paginator.New(b, data, opts...)
 }
 
 func handlerPaginator(ctx context.Context, b *bot.Bot, update *models.Update) {

--- a/examples/progress_custom.go
+++ b/examples/progress_custom.go
@@ -31,7 +31,7 @@ func handlerProgressCustom(ctx context.Context, b *bot.Bot, update *models.Updat
 		progress.WithRenderTextFunc(renderFunc),
 	}
 
-	p := progress.New(opts...)
+	p := progress.New(b, opts...)
 
 	p.Show(ctx, b, update.Message.Chat.ID)
 

--- a/examples/progress_simple.go
+++ b/examples/progress_simple.go
@@ -12,8 +12,8 @@ import (
 
 var demoProgressSimple *progress.Progress
 
-func initProgressSimple() {
-	demoProgressSimple = progress.New(progress.WithPrefix("progress-simple"))
+func initProgressSimple(b *bot.Bot) {
+	demoProgressSimple = progress.New(b, progress.WithPrefix("progress-simple"))
 }
 
 func handlerProgressSimple(ctx context.Context, b *bot.Bot, update *models.Update) {

--- a/examples/reply_keyboard.go
+++ b/examples/reply_keyboard.go
@@ -11,12 +11,7 @@ import (
 var demoReplyKeyboard *reply.ReplyKeyboard
 
 func initReplyKeyboard(b *bot.Bot) {
-	demoReplyKeyboard = reply.New(
-		b,
-		reply.WithPrefix("reply_keyboard"),
-		reply.IsSelective(),
-		reply.IsOneTimeKeyboard(),
-	).
+	demoReplyKeyboard = reply.New(reply.WithPrefix("reply_keyboard"), reply.IsSelective(), reply.IsOneTimeKeyboard()).
 		Button("Button", b, bot.MatchTypeExact, onReplyKeyboardSelect).
 		Row().
 		Button("Cancel", b, bot.MatchTypeExact, onReplyKeyboardSelect)

--- a/examples/slider.go
+++ b/examples/slider.go
@@ -39,7 +39,7 @@ func handlerSlider(ctx context.Context, b *bot.Bot, update *models.Update) {
 		slider.WithPrefix("slider"),
 	}
 
-	sl := slider.New(slides, opts...)
+	sl := slider.New(b, slides, opts...)
 
 	sl.Show(ctx, b, update.Message.Chat.ID)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-telegram/ui
 
 go 1.20
 
-require github.com/go-telegram/bot v1.1.5
+require github.com/go-telegram/bot v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,2 @@
-github.com/go-telegram/bot v0.7.13 h1:8VUBXtYwdh0skrCx6oORSrT0M9ZZaKIKIX3hC3XBs1A=
-github.com/go-telegram/bot v0.7.13/go.mod h1:i2TRs7fXWIeaceF3z7KzsMt/he0TwkVC680mvdTFYeM=
-github.com/go-telegram/bot v0.8.0 h1:LQZwaU5eqfXzeUIqDBOLrk6/Lu26zqwnBs5BOKQl7fU=
-github.com/go-telegram/bot v0.8.0/go.mod h1:i2TRs7fXWIeaceF3z7KzsMt/he0TwkVC680mvdTFYeM=
-github.com/go-telegram/bot v1.0.1 h1:Rxg5H6WLN36n1YWzw61O/+krbNM12E+d+BowkrFEcWA=
-github.com/go-telegram/bot v1.0.1/go.mod h1:i2TRs7fXWIeaceF3z7KzsMt/he0TwkVC680mvdTFYeM=
-github.com/go-telegram/bot v1.1.5 h1:M7LY0Y0gssqKJb466q/XXYsiklz6mylHG1AJQ6SMVTU=
-github.com/go-telegram/bot v1.1.5/go.mod h1:i2TRs7fXWIeaceF3z7KzsMt/he0TwkVC680mvdTFYeM=
+github.com/go-telegram/bot v1.8.3 h1:qywnDX+dKAzelJqij8eqlsUbw8SaCAE86GA6bMqGxCM=
+github.com/go-telegram/bot v1.8.3/go.mod h1:i2TRs7fXWIeaceF3z7KzsMt/he0TwkVC680mvdTFYeM=

--- a/keyboard/reply/keyboard.go
+++ b/keyboard/reply/keyboard.go
@@ -20,7 +20,7 @@ type ReplyKeyboard struct {
 	markup [][]models.KeyboardButton
 }
 
-func New(b *bot.Bot, opts ...Option) *ReplyKeyboard {
+func New(opts ...Option) *ReplyKeyboard {
 	kb := &ReplyKeyboard{
 		inputFieldPlaceholder: "",
 		selective:             false,

--- a/paginator/keyboard.go
+++ b/paginator/keyboard.go
@@ -9,30 +9,46 @@ import (
 func (p *Paginator) buildKeyboard() models.InlineKeyboardMarkup {
 	var row []models.InlineKeyboardButton
 
-	row = append(row, models.InlineKeyboardButton{Text: "\u00AB 1", CallbackData: p.prefix + cmdStart})
+	if p.withoutEmptyButtons && p.pagesCount <= 7 {
+		if p.pagesCount > 1 {
+			for i := 1; i <= p.pagesCount; i++ {
+				callbackCommand := strconv.Itoa(i)
+				buttonText := strconv.Itoa(i)
+				if i == p.currentPage {
+					buttonText = "( " + buttonText + " )"
+				}
 
-	startPage := p.calcStartPage()
-
-	for i := startPage; i < startPage+5; i++ {
-		callbackCommand := strconv.Itoa(i)
-		buttonText := strconv.Itoa(i)
-		if i > p.pagesCount {
-			callbackCommand = cmdNop
-			buttonText = " "
+				row = append(row, models.InlineKeyboardButton{Text: buttonText, CallbackData: p.prefix + callbackCommand})
+			}
 		}
-		if i == p.currentPage {
-			buttonText = "( " + buttonText + " )"
+	} else {
+		row = append(row, models.InlineKeyboardButton{Text: "\u00AB 1", CallbackData: p.prefix + cmdStart})
+
+		startPage := p.calcStartPage()
+
+		for i := startPage; i < startPage+5; i++ {
+			callbackCommand := strconv.Itoa(i)
+			buttonText := strconv.Itoa(i)
+			if i > p.pagesCount {
+				callbackCommand = cmdNop
+				buttonText = " "
+			}
+			if i == p.currentPage {
+				buttonText = "( " + buttonText + " )"
+			}
+
+			row = append(row, models.InlineKeyboardButton{Text: buttonText, CallbackData: p.prefix + callbackCommand})
 		}
 
-		row = append(row, models.InlineKeyboardButton{Text: buttonText, CallbackData: p.prefix + callbackCommand})
+		row = append(row, models.InlineKeyboardButton{Text: strconv.Itoa(p.pagesCount) + " \u00BB", CallbackData: p.prefix + cmdEnd})
 	}
 
-	row = append(row, models.InlineKeyboardButton{Text: strconv.Itoa(p.pagesCount) + " \u00BB", CallbackData: p.prefix + cmdEnd})
-
 	kb := models.InlineKeyboardMarkup{
-		InlineKeyboard: [][]models.InlineKeyboardButton{
-			row,
-		},
+		InlineKeyboard: [][]models.InlineKeyboardButton{},
+	}
+
+	if len(row) > 0 {
+		kb.InlineKeyboard = append(kb.InlineKeyboard, row)
 	}
 
 	if p.closeButton != "" {

--- a/paginator/options.go
+++ b/paginator/options.go
@@ -36,3 +36,10 @@ func WithPrefix(s string) Option {
 		w.prefix = s
 	}
 }
+
+// WithoutEmptyButtons is a keyboard option that hides empty buttons
+func WithoutEmptyButtons() Option {
+	return func(p *Paginator) {
+		p.withoutEmptyButtons = true
+	}
+}

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -18,14 +18,15 @@ const (
 )
 
 type Paginator struct {
-	data        []string
-	perPage     int
-	currentPage int
-	pagesCount  int
-	separator   string
-	prefix      string
-	closeButton string
-	onError     OnErrorHandler
+	data                []string
+	perPage             int
+	currentPage         int
+	pagesCount          int
+	separator           string
+	prefix              string
+	closeButton         string
+	onError             OnErrorHandler
+	withoutEmptyButtons bool
 
 	callbackHandlerID string
 }

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -30,7 +30,7 @@ type Paginator struct {
 	callbackHandlerID string
 }
 
-func New(data []string, opts ...Option) *Paginator {
+func New(b *bot.Bot, data []string, opts ...Option) *Paginator {
 	p := &Paginator{
 		prefix:      bot.RandomString(16),
 		data:        data,
@@ -49,6 +49,8 @@ func New(data []string, opts ...Option) *Paginator {
 		p.pagesCount++
 	}
 
+	p.callbackHandlerID = b.RegisterHandler(bot.HandlerTypeCallbackQueryData, p.prefix, bot.MatchTypePrefix, p.callback)
+
 	return p
 }
 
@@ -62,8 +64,6 @@ func defaultOnError(err error) {
 }
 
 func (p *Paginator) Show(ctx context.Context, b *bot.Bot, chatID any) (*models.Message, error) {
-	p.callbackHandlerID = b.RegisterHandler(bot.HandlerTypeCallbackQueryData, p.prefix, bot.MatchTypePrefix, p.callback)
-
 	return b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:      chatID,
 		Text:        p.buildText(),

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -28,7 +28,7 @@ type Progress struct {
 	canceled          bool
 }
 
-func New(opts ...Option) *Progress {
+func New(b *bot.Bot, opts ...Option) *Progress {
 	p := &Progress{
 		prefix:         bot.RandomString(16),
 		value:          0,
@@ -38,6 +38,11 @@ func New(opts ...Option) *Progress {
 
 	for _, opt := range opts {
 		opt(p)
+	}
+
+	if p.onCancel != nil {
+		p.onCancelHandlerId = b.RegisterHandler(bot.HandlerTypeCallbackQueryData, p.prefix,
+			bot.MatchTypeExact, p.onCancelCall)
 	}
 
 	return p
@@ -63,11 +68,6 @@ func (p *Progress) Show(ctx context.Context, b *bot.Bot, chatID any) error {
 
 	if err != nil {
 		return err
-	}
-
-	if p.onCancel != nil {
-		p.onCancelHandlerId = b.RegisterHandler(bot.HandlerTypeCallbackQueryData, p.prefix,
-			bot.MatchTypeExact, p.onCancelCall)
 	}
 
 	p.message = m

--- a/slider/slider.go
+++ b/slider/slider.go
@@ -44,7 +44,7 @@ type Slider struct {
 	callbackHandlerID string
 }
 
-func New(slides []Slide, opts ...Option) *Slider {
+func New(b *bot.Bot, slides []Slide, opts ...Option) *Slider {
 	s := &Slider{
 		prefix:         bot.RandomString(16),
 		slides:         slides,
@@ -56,6 +56,8 @@ func New(slides []Slide, opts ...Option) *Slider {
 	for _, opt := range opts {
 		opt(s)
 	}
+
+	s.callbackHandlerID = b.RegisterHandler(bot.HandlerTypeCallbackQueryData, s.prefix, bot.MatchTypePrefix, s.callback)
 
 	return s
 }
@@ -70,8 +72,6 @@ func defaultOnError(err error) {
 }
 
 func (s *Slider) Show(ctx context.Context, b *bot.Bot, chatID any) (*models.Message, error) {
-	s.callbackHandlerID = b.RegisterHandler(bot.HandlerTypeCallbackQueryData, s.prefix, bot.MatchTypePrefix, s.callback)
-
 	slide := s.slides[s.current]
 
 	sendParams := &bot.SendPhotoParams{


### PR DESCRIPTION
- update bot lib version to v1.8.3
- add option `paginator.WithoutEmptyButtons`
- BREAKING: change signature of `dialog.New()`, `paginator.New()`, `progress.New()`, `slider.New()` method. Add `bot.Bot` as first argument
